### PR TITLE
Cleanup feature without Ruby code

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -94,6 +94,12 @@ task :unpack do
     }
   }
 
+  File.open("payload.txt") do |f|
+    f.each_line do |i|
+      puts "remove: #{i}"
+      FileUtils.rm_rf "#{LATEST_DIR}/#{i}"
+    end
+  end
 end
 
 task :index => :index_codesearch

--- a/Rakefile
+++ b/Rakefile
@@ -143,22 +143,25 @@ def fix_permission(dir)
   }
 end
 
-EXT_NAMES = %w(.rb .ru .gemspec .rake .cmd .gemfile .thor .c .h .cpp .hpp)
+RB_EXT_NAMES = %w(.rb .ru .gemspec .rake .cmd .gemfile .thor)
+C_EXT_NAMES = %w(.c .h .cpp .hpp)
 def clean_files(dir)
   return unless File.exist? dir
   Find.find(dir) {|fn|
     st = File.lstat(fn)
     if st.file?
-      if !(EXT_NAMES.any?{|ext| fn.end_with?(ext)} || Pathname(fn).extname.empty?)
+      if C_EXT_NAMES.any?{|ext| fn.end_with?(ext)}
+        next
+      elsif !(EXT_NAMES.any?{|ext| fn.end_with?(ext)} || Pathname(fn).extname.empty?)
         File.unlink fn
         puts "removed: #{fn}"
         next
-      end
-
-      _, _, _, wait_thr = *Open3.popen3("ruby -c #{fn}")
-      if wait_thr.value.exitstatus != 0
-        File.unlink fn
-        puts "removed: #{fn}"
+      else
+        _, _, _, wait_thr = *Open3.popen3("ruby -c #{fn}")
+        if wait_thr.value.exitstatus != 0
+          File.unlink fn
+          puts "removed: #{fn}"
+        end
       end
     end
   }

--- a/Rakefile
+++ b/Rakefile
@@ -98,9 +98,10 @@ task :unpack do
 
   File.open("payload.txt") do |f|
     f.each_line do |i|
+      i.chomp!
       if File.exist? i
-        puts "remove: #{i}"
         File.unlink "#{LATEST_DIR}/#{i}"
+        puts "removed: #{i}"
       end
     end
   end

--- a/Rakefile
+++ b/Rakefile
@@ -96,8 +96,10 @@ task :unpack do
 
   File.open("payload.txt") do |f|
     f.each_line do |i|
-      puts "remove: #{i}"
-      FileUtils.rm_rf "#{LATEST_DIR}/#{i}"
+      if File.exist? f
+        puts "remove: #{i}"
+        File.unlink "#{LATEST_DIR}/#{i}"
+      end
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -142,7 +142,7 @@ def fix_permission(dir)
   }
 end
 
-EXT_NAMES = %w(.rb .ru .gemspec .rake .cmd .gemfile .thor)
+EXT_NAMES = %w(.rb .ru .gemspec .rake .cmd .gemfile .thor .c .h .cpp .hpp)
 def clean_files(dir)
   return unless File.exist? dir
   Find.find(dir) {|fn|

--- a/Rakefile
+++ b/Rakefile
@@ -152,7 +152,7 @@ def clean_files(dir)
     if st.file?
       if C_EXT_NAMES.any?{|ext| fn.end_with?(ext)}
         next
-      elsif !(EXT_NAMES.any?{|ext| fn.end_with?(ext)} || Pathname(fn).extname.empty?)
+      elsif !(RB_EXT_NAMES.any?{|ext| fn.end_with?(ext)} || Pathname(fn).extname.empty?)
         File.unlink fn
         puts "removed: #{fn}"
         next

--- a/Rakefile
+++ b/Rakefile
@@ -98,7 +98,7 @@ task :unpack do
 
   File.open("payload.txt") do |f|
     f.each_line do |i|
-      if File.exist? f
+      if File.exist? i
         puts "remove: #{i}"
         File.unlink "#{LATEST_DIR}/#{i}"
       end

--- a/Rakefile
+++ b/Rakefile
@@ -150,13 +150,14 @@ def clean_files(dir)
     if st.file?
       if !(EXT_NAMES.any?{|ext| fn.end_with?(ext)} || Pathname(fn).extname.empty?)
         File.unlink fn
+        puts "removed: #{fn}"
         next
       end
 
       _, _, _, wait_thr = *Open3.popen3("ruby -c #{fn}")
       if wait_thr.value.exitstatus != 0
-        puts "removed: #{fn}"
         File.unlink fn
+        puts "removed: #{fn}"
       end
     end
   }

--- a/payload.txt
+++ b/payload.txt
@@ -1,0 +1,11 @@
+EICAR-0.0.6/bin/eicar.com
+clamd-1.0.1/spec/fixtures/virus
+clamrb-0.0.3/test/files/eicar.txt
+clamav-0.4.1/spec/clamav-testfiles/eicar.com
+clamav-0.4.1/spec/clamav-testfiles/test.txt
+metasploit-payloads-1.3.60/data/java/metasploit/RMILoader.class
+meterpreter_bins-0.0.22/meterpreter/metsrv.x64.dll
+meterpreter_bins-0.0.22/meterpreter/ext_server_priv.x86.dll
+metasploit-payloads-1.3.60/data/java/metasploit/Payload.class
+warp-clamav-0.3.1/spec/clamav-testfiles/eicar.com
+warp-clamav-0.3.1/spec/clamav-testfiles/test.txt

--- a/payload.txt
+++ b/payload.txt
@@ -9,3 +9,4 @@ meterpreter_bins-0.0.22/meterpreter/ext_server_priv.x86.dll
 metasploit-payloads-1.3.60/data/java/metasploit/Payload.class
 warp-clamav-0.3.1/spec/clamav-testfiles/eicar.com
 warp-clamav-0.3.1/spec/clamav-testfiles/test.txt
+video_to_ascii-0.0.3/bin/wacaw


### PR DESCRIPTION
I added the feature of cleanup files without Ruby code. I removed the following files.

* The vulnerable files detected by F-Secure Anti-Virus.
* The files what used extension name without `.rb`, `.rake` and the majority of Ruby code.
* The files that `ruby -c` raised error status.

I know this feature is slow down of `rake unpack` task.

@akr @mame How about this?