### PR TITLE
Introduce a new Rake target "index_csearch"

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ named `.zoekt` to HOME directory
     % cd gem-codesearch
     % rake all >& setup.log             # It may take several days or more
 
-## Use milkode instead of codesesarch
+## Use milkode instead of zoekt
 
     % gem install milkode
     % milk init --default               # If you use milkode first time

--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ named `.zoekt` to HOME directory
     % milk init --default               # If you use milkode first time
     % rake mirror unpack index_milkode >& setup.log
 
+## Use codesearch instead of zoekt
+
+    $ rake mirror unpack index_csearch
+
+This creates a set of indexes for csearch in gem-codesearch/csearchindexes.
+Use a wrapper shell script to call csearch:
+
+```
+#!/bin/sh
+
+export CSEARCHINDEX
+for CSEARCHINDEX in /path/to/gem-codesearch/csearchindexes/?; do csearch "$@"; done
+```
+
 ## Links
 
 - https://github.com/akr/gem-codesearch

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,7 @@ Usage:
   rake index_zoekt
   rake index_codesearch # same as index_zoekt (for compatibility)
   rake index_milkode
+  rake index_csearch
 End
 end
 
@@ -104,6 +105,17 @@ INDEX_COMMAND = 'zoekt-index'
 task :index_zoekt do
   FileUtils.rm_rf("zoekt-index")
   sh INDEX_COMMAND, "-index", "zoekt-index", LATEST_DIR
+end
+
+CSEARCH_COMMAND = 'cindex'
+task :index_csearch do
+  dir = File.join(BASE_DIR, "csearchindexes")
+  FileUtils.mkpath dir
+  [nil, *?a..?z].each do |prefix|
+    env = { "CSEARCHINDEX" => File.join(dir, prefix || '_') }
+    paths = Dir.glob(File.join(LATEST_DIR, ((prefix || '[ -_]') + "*"))).sort
+    sh env, CSEARCH_COMMAND, "-reset", *paths
+  end
 end
 
 task :index_milkode do

--- a/Rakefile
+++ b/Rakefile
@@ -12,8 +12,9 @@ Usage:
   rake all              # mirror, unpack, index
   rake mirror
   rake unpack
-  rake index            # same as index_codesearch
-  rake index_codesearch
+  rake index            # same as index_zoekt
+  rake index_zoekt
+  rake index_codesearch # same as index_zoekt (for compatibility)
   rake index_milkode
 End
 end
@@ -96,10 +97,11 @@ task :unpack do
 
 end
 
-task :index => :index_codesearch
+task :index => :index_zoekt
+task :index_codesearch => :index_zoekt # for compatibility
 
 INDEX_COMMAND = 'zoekt-index'
-task :index_codesearch do
+task :index_zoekt do
   FileUtils.rm_rf("zoekt-index")
   sh INDEX_COMMAND, "-index", "zoekt-index", LATEST_DIR
 end


### PR DESCRIPTION
Unfortuantely, csearch has a hard-coded limit of 4GB for its index
(#6).
But it is still useful because it is faster to invoke than zoekt.

This changeset introduces a new Rake target "index_csearch", to create
separated 26 indexes for each lowercase alphabet prefix (and one more
index for other prefix such as punctuation and uppercase alphabets).

Also, a new target "index_zoekt" is added to make it clear, and
the old target "index_codesearch" is kept as an alias to "index_zoekt"
for compatibility.